### PR TITLE
Moved secrets to environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SECRET_KEY_BASE=foo

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .tape
 .byebug_history
 /.bundle
-/config/secrets.yml
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /log/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.4.2
 before_script:
-  - cp config/secrets.example.yml config/secrets.yml
   - psql -c 'create database dc_timetracker_test;' -U postgres
   - bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare --trace

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "bundler-audit"
   gem "codeclimate-test-reporter", "~> 1.0.0"
   gem "database_cleaner"
+  gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "faker"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.4.0)
+    dotenv-rails (2.4.0)
+      dotenv (= 2.4.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -322,6 +326,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   devise
+  dotenv-rails
   factory_bot_rails
   faker
   letter_opener

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,5 +1,5 @@
 default: &default
-  secret_key_base: secret
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 development:
   <<: *default
@@ -13,5 +13,6 @@ test:
 # and move the `production:` environment over there.
 
 production:
+  <<: *default
   mailgun_api_key: <%= ENV["MAILGUN_API_KEY"] %>
   mailgun_domain: <%= ENV["MAILGUN_DOMAIN"] %>

--- a/spec/rspec_examples.txt
+++ b/spec/rspec_examples.txt
@@ -1,0 +1,4 @@
+example_id                       | status  | run_time        |
+-------------------------------- | ------- | --------------- |
+./spec/models/user_spec.rb[1:1]  | pending | 0.00002 seconds |
+./spec/seeds/seed_spec.rb[1:1:1] | passed  | 0.14686 seconds |


### PR DESCRIPTION
## Why?
- Since we're deploying to heroku, we need secrets to not be gitignored

## What Changed?
- Remove secrets.yml from gitignore
- Configure secret_key_base to read from ENV variable
- Add dotenv-rails
- Add a .env file